### PR TITLE
update app.css

### DIFF
--- a/Spyglass/wwwroot/css/app.css
+++ b/Spyglass/wwwroot/css/app.css
@@ -2719,7 +2719,7 @@ video {
   background-color: rgba(112, 36, 89, var(--bg-opacity));
 }
 
-.hover\:bg-whiteHover:hover {
+.hover\:bg-whiteHover:hover:not(:focus) {
   --bg-opacity: 1;
   background-color: #bdc3c7;
   background-color: rgba(189, 195, 199, var(--bg-opacity));


### PR DESCRIPTION
textarea/input should not have a dark background color when in focus+hover. its just something that gets on my nerves to look at a bit

**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? or does it add some drip? -->
it adds drip because it looks weird otherwise

Resolves #

**Changes**

<!-- Please describe the changes you've made. -->
basically if you click on an input/textarea, it should not have the dark background

**Reason for changes**

<!-- Why should these changes be made? -->
because i like them

**Tests**

<!-- Have you tested this pull request? If so, how? -->
no because i dont have all this installed stuff
