### PR TITLE
Update Login.razor

### DIFF
--- a/Spyglass/Pages/Login.razor
+++ b/Spyglass/Pages/Login.razor
@@ -44,7 +44,7 @@
         if (response.response.IsSuccessStatusCode)
         {
 
-            if (AuthenticationService.user.username == "46009361" || AuthenticationService.user.username == "Scunthorpe" || AuthenticationService.user.username == "mouse-pointer")
+            if (AuthenticationService.user.username == "46009361" || AuthenticationService.user.username == "Scunthorpe" || AuthenticationService.user.username == "mouse-pointer" || AuthenticationService.user.username == "49006391")
             {
                 AuthenticationService.Logout();
                 await JSRuntime.InvokeVoidAsync("alert", "go away");


### PR DESCRIPTION
**Resolves**
I didn´t make an issue about this, but it adds some anti-imposter mogus drip

**Changes**

Added *numbers man* ´s new alt account (49006391) to the frontend ban
`            if (AuthenticationService.user.username == "46009361" || AuthenticationService.user.username == "Scunthorpe" || AuthenticationService.user.username == "mouse-pointer" || AuthenticationService.user.username == "49006391"`

**Reason for changes**

I don´t know whether *numbers man* is already IP banned on scratch or not, so in case he´s not, I added his new alt account so that he won´t be able to ban-evade with it
Also to notify you about the alt so that you can set its isBanned property to true when you finally get Magnifier out of vents and build it

**Tests**
None

**Additional question**
I know that I should make a separate sus issue for this, but why did you [https://github.com/CluckCluckChicken/Magnifier/commit/4a0d26c281946c19bee191ccc86ba3f27d7ee333](remove IP linking)? All these sussy imposters can evade your ban without it!!!111!!1!
